### PR TITLE
Approve squeak

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Update a squeak by ID.
    | **id** | Squeak primary key (required) | String | True  |
    | **report** | Report argument | Boolean | False |
    | **nut** | Nut argument | Boolean | False |
+   | **approved** | Whether a squeak has been approved by a moderator | Boolean | False |
 
   <br>
 
@@ -604,9 +605,6 @@ mutation {
 }
  ```
 
- ---
-
-
  **Sample mutation (Approved)**
 
  ```graphql
@@ -629,9 +627,10 @@ mutation {
   "data": {
     "updateSqueak": {
       "squeak": {
-        "id": "3",
-        "content": "I sure hope this squeak stays up forever",
-        "nuts": 1
+        "id": "7",
+        "content": "This is squeak #6",
+        "approved": true,
+        "reports": 0
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -426,7 +426,8 @@ Add a squeak.
    | Parameter | Description | Data type |
    | --------- | ----------- | --------- |
    | **content** | Squeak message content (required) | String        |
-   | **user_id** | Squeak message contant (required) | ID       |
+   | **user_id** | Squeak message content (required) | ID       |
+   | **approved** | Whether a squeak has been approved by a moderator | Boolean |
 
 
   <br>
@@ -478,6 +479,38 @@ mutation {
 	     }  
 	}  
    }
+}
+ ```
+
+
+ **Sample mutation (Approved)**
+
+ ```graphql
+mutation {
+  updateSqueak(input: {id: 7, approved: true }) {
+    squeak {
+      id
+      content
+      approved
+      reports
+    }
+  }
+}
+```
+
+**Sample response (Approved) (status 200)**
+
+ ```json
+{
+  "data": {
+    "updateSqueak": {
+      "squeak": {
+        "id": "3",
+        "content": "I sure hope this squeak stays up forever",
+        "nuts": 1
+      }
+    }
+  }
 }
  ```
 <!-- BADGE LINKS -->

--- a/app/graphql/mutations/update_squeak.rb
+++ b/app/graphql/mutations/update_squeak.rb
@@ -3,16 +3,20 @@ module Mutations
     argument :id, ID, required: true
     argument :report, Boolean, required: false
     argument :nut, Boolean, required: false
+    argument :approve, Boolean, required: false
 
     field :squeak, Types::SqueakType, null: false
 
-    def resolve(id: , report: false, nut: false)
+    def resolve(id: , report: false, nut: false, approve: nil)
       squeak = Squeak.find(id)
       if squeak
         if report == true
           squeak.reports += 1
         elsif nut == true
           squeak.nuts += 1
+        elsif approve == true
+          squeak.approved = true
+          squeak.reports = 0
         end
         squeak.save
       end

--- a/app/graphql/mutations/update_squeak.rb
+++ b/app/graphql/mutations/update_squeak.rb
@@ -3,26 +3,33 @@ module Mutations
     argument :id, ID, required: true
     argument :report, Boolean, required: false
     argument :nut, Boolean, required: false
-    argument :approve, Boolean, required: false
+    argument :approved, Boolean, required: false
 
     field :squeak, Types::SqueakType, null: false
 
-    def resolve(id: , report: false, nut: false, approve: nil)
+    def resolve(id: , report: false, nut: false, approved: nil)
       squeak = Squeak.find(id)
       if squeak
-        if report == true
-          squeak.reports += 1
-        elsif nut == true
-          squeak.nuts += 1
-        elsif approve == true
-          squeak.approved = true
-          squeak.reports = 0
-        end
-        squeak.save
+        check_arguments(squeak, report, nut, approved)
       end
       { squeak: squeak }
       rescue ActiveRecord::RecordNotFound => e
         GraphQL::ExecutionError.new(e)
+    end
+
+    def check_arguments(squeak, report, nut, approved)
+      squeak.reports += 1 if report == true
+      squeak.nuts += 1 if nut == true
+
+      case approved
+      when true
+        squeak.approved = true
+        squeak.reports = 0
+      when false
+        squeak.approved = false
+      end
+
+      squeak.save
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_approval/When_an_admin_approves_a_squeak/The_reports_are_reset_to_0.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_approval/When_an_admin_approves_a_squeak/The_reports_are_reset_to_0.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Omnis consequatur nihil molestiae."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 12 Dec 2022 18:28:23 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 34,
+                  "score": {
+                    "value": 0.006881601,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.006881601,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Mon, 12 Dec 2022 18:28:25 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_approval/When_an_admin_approves_a_squeak/The_squeak_status_is_changed_to_approved.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_approval/When_an_admin_approves_a_squeak/The_squeak_status_is_changed_to_approved.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Sunt officiis quos quae."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 12 Dec 2022 18:27:49 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 24,
+                  "score": {
+                    "value": 0.0010128163,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.0010128163,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Mon, 12 Dec 2022 18:27:51 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_approval/When_an_admin_rejects_a_squeak/The_squeak_approved_boolean_is_changed_to_false.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_approval/When_an_admin_rejects_a_squeak/The_squeak_approved_boolean_is_changed_to_false.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Qui error eos numquam."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 12 Dec 2022 19:02:20 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 22,
+                  "score": {
+                    "value": 0.00103594,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.00103594,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Mon, 12 Dec 2022 19:02:22 GMT
+recorded_with: VCR 6.1.0

--- a/spec/graphql/squeaks/update_squeak_spec.rb
+++ b/spec/graphql/squeaks/update_squeak_spec.rb
@@ -145,4 +145,56 @@ RSpec.describe 'Update Squeak Mutation', :vcr do
       expect(errors.first.dig("path")).to eq(["updateSqueak"])
     end
   end
+  
+  describe 'Admin approval' do
+    describe 'When an admin approves a squeak' do
+      before :each do 
+        @query = <<~GQL
+          mutation {
+            updateSqueak(input: { id: 1, approved: true }) {
+              squeak {
+                id
+                content
+                reports
+                nuts
+                approved
+                score{
+                  metric
+                  probability
+                }
+              }
+            }
+          }
+        GQL
+      end
+
+      it 'The squeak status is changed to approved' do
+        expect(@squeak.approved).to be_nil
+
+        result = SqueakrBeSchema.execute(@query)
+        expect(result.dig("data")).to be_a(Hash)
+        expect(result.dig("data", "updateSqueak", "squeak")).to be_a(Hash)
+        squeak_return = result.dig("data", "updateSqueak", "squeak")
+        expect(squeak_return.dig("approved")).to eq 'true'
+        expect(@squeak.approved).to be(true)
+      end
+
+      it 'The reports are reset to 0' do 
+        @squeak.reports = 5
+
+        result = SqueakrBeSchema.execute(@query)
+        expect(result.dig("data")).to be_a(Hash)
+        expect(result.dig("data", "updateSqueak", "squeak")).to be_a(Hash)
+        squeak_return = result.dig("data", "updateSqueak", "squeak")
+        expect(squeak_return.dig("reports")).to eq 0
+        expect(@squeak.reports).to eq(0)
+      end
+    end
+
+    describe 'When an admin rejects a squeak' do 
+
+      it 'The squeak approved boolean is changed to false'
+
+    end
+  end
 end


### PR DESCRIPTION
### User Story Implemented
An admin can approve or reject a squeak.

### Describe Features Added/Changed
See above. Also refactored the update method to use a helper method instead of a giant nested if block.

### Describe Tests Added/Changed
Added testing for approving and disapproving a squeak, and approving a squeak will reset reports to zero. 

### Checklist before requesting a review
- [x] Added features have thorough tests written for their functionality?
- [x] All Tests Passing?
