### PR TITLE
Add permitted scope to all squeaks

### DIFF
--- a/app/graphql/queries/all_squeaks.rb
+++ b/app/graphql/queries/all_squeaks.rb
@@ -4,7 +4,7 @@ module Queries
     type [Types::SqueakType], null: false
 
     def resolve
-      Squeak.all.order(created_at: :desc)
+      Squeak.permitted.order(created_at: :desc)
     end
   end
 end

--- a/app/models/squeak.rb
+++ b/app/models/squeak.rb
@@ -3,7 +3,8 @@ class Squeak < ApplicationRecord
   validates :content, presence: true
   # validate :filter
 
-  scope :reported, -> { where('reports > 0') }
+  scope :reported, -> { permitted.where('reports > 0') }
+  scope :permitted, -> { where('approved != false') }
 
   def score
     ScoreFetcher.fetch_score(self)

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_actions/approval_of_reported_squeaks/resets_reports_count_to_0_after_approval.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_actions/approval_of_reported_squeaks/resets_reports_count_to_0_after_approval.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Atque natus repellendus reprehenderit."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Tue, 13 Dec 2022 17:35:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 38,
+                  "score": {
+                    "value": 0.0005387813,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.0005387813,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Tue, 13 Dec 2022 17:35:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_actions/approval_of_reported_squeaks/updates_squeaks_approved_status_to_true.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_actions/approval_of_reported_squeaks/updates_squeaks_approved_status_to_true.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Tenetur molestias aperiam sunt."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Tue, 13 Dec 2022 17:35:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 31,
+                  "score": {
+                    "value": 0.0017204003,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.0017204003,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Tue, 13 Dec 2022 17:35:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_actions/rejection_of_reported_squeak/updates_approved_status_to_false.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/Admin_actions/rejection_of_reported_squeak/updates_approved_status_to_false.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Unde architecto ut vel."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Tue, 13 Dec 2022 17:35:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 23,
+                  "score": {
+                    "value": 0.0007815797,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.0007815797,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Tue, 13 Dec 2022 17:35:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/reporting_a_squeak/does_not_change_any_other_squeak_values_when_reported.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/reporting_a_squeak/does_not_change_any_other_squeak_values_when_reported.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Consequatur atque voluptas aut."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Tue, 13 Dec 2022 17:35:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 31,
+                  "score": {
+                    "value": 0.00022776806,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.00022776806,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Tue, 13 Dec 2022 17:35:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/reporting_a_squeak/is_assigned_a_score_when_reported.yml
+++ b/spec/fixtures/vcr_cassettes/Update_Squeak_Mutation/reporting_a_squeak/is_assigned_a_score_when_reported.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=<PERSPECTIVE_KEY>
+    body:
+      encoding: UTF-8
+      string: '{"comment":{"text":"Autem corporis deserunt quis."},"languages":["en"],"requestedAttributes":{"IDENTITY_ATTACK":{}}}'
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Tue, 13 Dec 2022 17:35:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "attributeScores": {
+            "IDENTITY_ATTACK": {
+              "spanScores": [
+                {
+                  "begin": 0,
+                  "end": 29,
+                  "score": {
+                    "value": 0.0007630808,
+                    "type": "PROBABILITY"
+                  }
+                }
+              ],
+              "summaryScore": {
+                "value": 0.0007630808,
+                "type": "PROBABILITY"
+              }
+            }
+          },
+          "languages": [
+            "en"
+          ],
+          "detectedLanguages": [
+            "la"
+          ]
+        }
+  recorded_at: Tue, 13 Dec 2022 17:35:42 GMT
+recorded_with: VCR 6.1.0

--- a/spec/models/squeak_spec.rb
+++ b/spec/models/squeak_spec.rb
@@ -25,12 +25,22 @@ RSpec.describe Squeak, type: :model do
     let(:squeak1) { squeaks.first }
     let(:squeak2) { squeaks.second }
     let(:squeak3) { squeaks.third }
+    let(:squeak4) { create(:squeak, approved: false) }
+    
 
     describe '::reported' do
       it 'scopes reported squeaks' do
         Squeak.reported.each do |squeak|
 
           expect(squeak.reports).to be > 0
+        end
+      end
+    end
+
+    describe '::permitted' do 
+      it 'scopes squeaks that have not been unapproved by the moderator' do 
+        Squeak.permitted.each do |squeak|
+          expect(squeak.permitted).to eq(false)
         end
       end
     end


### PR DESCRIPTION


### User Story Implemented
As a developer, when I query allSqueaks from the backend, I should only see squeaks with an approved attribute of true or nil.

### Describe Features Added/Changed
Added a permitted scope to show only squeaks that are either awaiting approval or approved. 
Combined this with the reported scope so similar functionality will occur when querying for reported squeaks.

### Describe Tests Added/Changed

Added integration tests to make sure the graphql query was only receiving the squeaks we want.
Added a unit test to make sure the scope is functioning as required.

### Checklist before requesting a review
- [x] Added features have thorough tests written for their functionality?
- [x] All Tests Passing?
